### PR TITLE
Add eth_sign_typed_data_v4

### DIFF
--- a/walletconnect/src/main/java/com/trustwallet/walletconnect/WCClient.kt
+++ b/walletconnect/src/main/java/com/trustwallet/walletconnect/WCClient.kt
@@ -283,7 +283,8 @@ open class WCClient (
                     throw InvalidJsonRpcParamsException(request.id)
                 onEthSign(request.id, WCEthereumSignMessage(params, WCEthereumSignMessage.WCSignType.PERSONAL_MESSAGE))
             }
-            WCMethod.ETH_SIGN_TYPE_DATA -> {
+            WCMethod.ETH_SIGN_TYPE_DATA,
+            WCMethod.ETH_SIGN_TYPE_DATA_V4 -> {
                 val params = gson.fromJson<List<String>>(request.params)
                 if (params.size < 2)
                     throw InvalidJsonRpcParamsException(request.id)

--- a/walletconnect/src/main/java/com/trustwallet/walletconnect/models/WCMethod.kt
+++ b/walletconnect/src/main/java/com/trustwallet/walletconnect/models/WCMethod.kt
@@ -18,6 +18,9 @@ enum class WCMethod {
     @SerializedName("eth_signTypedData")
     ETH_SIGN_TYPE_DATA,
 
+    @SerializedName("eth_signTypedData_v4")
+    ETH_SIGN_TYPE_DATA_V4,
+
     @SerializedName("eth_signTransaction")
     ETH_SIGN_TRANSACTION,
 

--- a/walletconnect/src/main/java/com/trustwallet/walletconnect/models/WCMethod.kt
+++ b/walletconnect/src/main/java/com/trustwallet/walletconnect/models/WCMethod.kt
@@ -34,5 +34,8 @@ enum class WCMethod {
     GET_ACCOUNTS,
 
     @SerializedName("trust_signTransaction")
-    SIGN_TRANSACTION;
+    SIGN_TRANSACTION,
+
+    @SerializedName("wallet_switchEthereumChain")
+    WALLET_SWITCH_NETWORK;
 }

--- a/walletconnect/src/main/java/com/trustwallet/walletconnect/models/session/WCAddNetwork.kt
+++ b/walletconnect/src/main/java/com/trustwallet/walletconnect/models/session/WCAddNetwork.kt
@@ -1,0 +1,8 @@
+package com.trustwallet.walletconnect.models.session
+
+import com.google.gson.annotations.SerializedName
+
+data class WCChangeNetwork(
+    @SerializedName("chainId")
+    val chainIdHex: String
+)

--- a/walletconnect/src/main/java/com/trustwallet/walletconnect/models/session/WCChangeNetwork.kt
+++ b/walletconnect/src/main/java/com/trustwallet/walletconnect/models/session/WCChangeNetwork.kt
@@ -1,0 +1,8 @@
+package com.trustwallet.walletconnect.models.session
+
+import com.google.gson.annotations.SerializedName
+
+data class WCChangeNetwork(
+    @SerializedName("chainId")
+    val chainIdHex: String
+)


### PR DESCRIPTION
Added this method, because some dApps send it instead of regular `eth_sign_typed_data`
https://docs.metamask.io/guide/signing-data.html#sign-typed-data-v4

dApp example: https://showtime.xyz